### PR TITLE
add parameter cert_group for read access to private files

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,6 +14,7 @@ default['ssl-vault']['certificates'] = []
 # These are currently Ubuntu-centric:
 default['ssl-vault']['certificate_directory'] = '/etc/ssl/certs'
 default['ssl-vault']['private_key_directory'] = '/etc/ssl/private'
+default['ssl-vault']['cert_group'] = 'root'
 
 # There's limits on Data Bag Key names:
 default['ssl-vault']['data_bag_key_rex'] = /[^[:alnum:]_-]+/

--- a/recipes/combined_chain_pem_file.rb
+++ b/recipes/combined_chain_pem_file.rb
@@ -34,8 +34,8 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     template combined_chain_pem_file do
       source 'combined.pem.erb'
       owner 'root'
-      group 'root'
-      mode '0400'
+      group node['ssl-vault']['cert_group']
+      mode '0440'
       variables(
         :certificate => vault_item['certificate'],
         :chain_certificates => vault_item['chain_certificates'],

--- a/recipes/pem_file.rb
+++ b/recipes/pem_file.rb
@@ -32,8 +32,8 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
   template pem_file do
     source 'pem.erb'
     owner 'root'
-    group 'root'
-    mode '0400'
+    group node['ssl-vault']['cert_group']
+    mode '0440'
     variables(
       :key => vault_item['key'],
       :certificate => vault_item['certificate']

--- a/recipes/private_key_directory.rb
+++ b/recipes/private_key_directory.rb
@@ -11,6 +11,6 @@
 
 directory node['ssl-vault']['private_key_directory'] do
   owner 'root'
-  group 'root'
-  mode '0700'
+  group node['ssl-vault']['cert_group']
+  mode '0710'
 end

--- a/recipes/private_key_file.rb
+++ b/recipes/private_key_file.rb
@@ -32,8 +32,8 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
   file private_key do
     content vault_item['key']
     owner 'root'
-    group 'root'
-    mode '0400'
+    group node['ssl-vault']['cert_group']
+    mode '0440'
   end
 
   node.set['ssl-vault']['certificate'][cert_name]['private_key_file'] = private_key


### PR DESCRIPTION
Ubuntu has a group `ssl-cert` for system accounts that need to access private keys.
This PR adds an attribute `cert_group` that can be set to that group name, so that this group can still access the directory /etc/ssl/private, the created keys and combined pem files.

This PR does not include any logic to figure out what the name of that group should be, the default maintains backward compatibility (group `root`).
