### PR TITLE
Request: adding option to attribute to change the name of the data bag away from default: 'ssl-vault'

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,8 +8,10 @@
 # Source:: https://github.com/onbeep-cookbooks/ssl-vault
 #
 
-
 default['ssl-vault']['certificates'] = []
+
+# If you already have a data bag named 'ssl-vault', change this.
+default['ssl-vault']['data_bag_name'] = 'ssl-vault'
 
 # These are currently Ubuntu-centric:
 default['ssl-vault']['certificate_directory'] = '/etc/ssl/certs'

--- a/recipes/certificate_file.rb
+++ b/recipes/certificate_file.rb
@@ -18,7 +18,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     node['ssl-vault']['data_bag_key_rex'],
     node['ssl-vault']['data_bag_key_replacement_str']
   )
-  vault_item = chef_vault_item('ssl-vault', clean_name)
+  vault_item = chef_vault_item("#{node['ssl-vault']['data_bag_name']}", clean_name)
 
   certificate_file = if node['ssl-vault']['certificate_file']
     node['ssl-vault']['certificate_file']

--- a/recipes/combined_chain_file.rb
+++ b/recipes/combined_chain_file.rb
@@ -18,7 +18,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     node['ssl-vault']['data_bag_key_rex'],
     node['ssl-vault']['data_bag_key_replacement_str']
   )
-  vault_item = chef_vault_item('ssl-vault', clean_name)
+  vault_item = chef_vault_item("#{node['ssl-vault']['data_bag_name']}", clean_name)
 
   if vault_item.key?('chain_certificates') and vault_item['chain_certificates']
 

--- a/recipes/combined_chain_pem_file.rb
+++ b/recipes/combined_chain_pem_file.rb
@@ -18,7 +18,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     node['ssl-vault']['data_bag_key_rex'],
     node['ssl-vault']['data_bag_key_replacement_str']
   )
-  vault_item = chef_vault_item('ssl-vault', clean_name)
+  vault_item = chef_vault_item("#{node['ssl-vault']['data_bag_name']}", clean_name)
 
   if vault_item.key?('chain_certificates') and vault_item['chain_certificates']
 

--- a/recipes/pem_file.rb
+++ b/recipes/pem_file.rb
@@ -18,7 +18,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     node['ssl-vault']['data_bag_key_rex'],
     node['ssl-vault']['data_bag_key_replacement_str']
   )
-  vault_item = chef_vault_item('ssl-vault', clean_name)
+  vault_item = chef_vault_item("#{node['ssl-vault']['data_bag_name']}", clean_name)
 
   pem_file = if node['ssl-vault']['pem_file']
     node['ssl-vault']['pem_file']

--- a/recipes/private_key_file.rb
+++ b/recipes/private_key_file.rb
@@ -18,7 +18,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     node['ssl-vault']['data_bag_key_rex'],
     node['ssl-vault']['data_bag_key_replacement_str']
   )
-  vault_item = chef_vault_item('ssl-vault', clean_name)
+  vault_item = chef_vault_item("#{node['ssl-vault']['data_bag_name']}", clean_name)
 
   private_key = if node['ssl-vault']['private_key_file']
     node['ssl-vault']['private_key_file']


### PR DESCRIPTION
So, I apologize in advance, I am really just learning chef/ruby and trying to get better, and in the department I'm joining they already have a data-bag named 'ssl-vault' but each file is in a very different format than listed in this project - I was wondering if we could add an option to change the data bag name in attributes, and then try using string interpolation to use that value when retrieving from the chef-vault?

again, i apologize if there are more technical underpinnings that make this unworkable, I'm still just starting out.

what's the correct way to start up the integration tests, and can I perform them without altering any data with my departments current chef server?

Thanks in advance,
Paul