### PR TITLE
Removed version constraint... 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'gba@onbeep.com'
 license          'The MIT License (MIT)'
 description      'SSL key & certificate storage in chef-vault.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '1.1.1'
+version          '2.0.0'
 
 supports 'ubuntu'
 
-depends 'chef-vault', '~> 1.0.4'
+depends 'chef-vault'


### PR DESCRIPTION
...so that consumers can constrain the version in their environment/wrapper cookbooks.

I'm not sure what your build/version process is for this cookbook.  I see the makefile, but I didn't want to run the bunde gem install since your versions conflict with mine.

I want to bump the major version since this could be a breaking change for users if they aren't constraining versions elsewhere.

Will fix: https://github.com/onbeep-cookbooks/ssl-vault/issues/5

Let me know how to do the versioning correctly. I can revert the version line to its original state if you're fine with this change, I just needed it at 2.0.0 so I can use my forked version in the mean time.