### PR TITLE
Setting version to be equal or greater than 1.0.4

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '1.1.1'
 
 supports 'ubuntu'
 
-depends 'chef-vault', '~> 1.0.4'
+depends 'chef-vault', '>= 1.0.4'


### PR DESCRIPTION
* Should address https://github.com/onbeep-cookbooks/ssl-vault/issues/5
* ssl-vault at a _minimum_ needs version 1.0.4, or greater